### PR TITLE
Clarify relationship to Lumafly in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🦋 LumaflyV2 (previously Lumafly)
+# 🦋 LumaflyV2
 
 ![build](https://github.com/Aarav2709/LumaflyV2/actions/workflows/build.yml/badge.svg)
 [![website](https://img.shields.io/badge/website-online-32c854)](https://lumaflyv2.vercel.app)
@@ -9,13 +9,12 @@
 
 </div>
 
-LumaflyV2 is a refreshed, production-ready evolution of the original Lumafly installer. It focuses on first-class support for Hollow Knight: Silksong, improved stability when installing mods, and a cleaner, more maintainable codebase with better localization support.
+LumaflyV2 is a refreshed, production-ready evolution of the original Lumafly installer. It focuses on first-class support for Hollow Knight: Silksong, improved stability when installing mods, and a cleaner, more maintainable codebase with better localization support. LumaflyV2 is not affiliated with Lumafly or its developers.
 
 Key improvements in LumaflyV2:
 
 - Reworked game profile system: automatic detection and per-game executable resolution (better Silksong support).
 - Safer installer flow with improved error handling around file access and mod installation.
-- Better internationalization and updated translations.
 - Small UX improvements: clearer messages, improved settings persistence, and fewer edge-case crashes.
 
 ## 🎮 Usage


### PR DESCRIPTION
The objective of this PR is to more accurately reflect the relationship to the existing Lumafly installer. Upstream, this is already causing confusion and we are seeing issues cut to the Lumafly repository which belong here, such as https://github.com/TheMulhima/Lumafly/issues/172

Lumafly says "formerly scarab+" because it was formerly called scarab+. In contrast, this was not formerly called anything, since it's "new" (as much as a fork can be new). As such I have removed this part of the readme. I have also more clearly called out that this is not affiliated with the upstream project, which I have seen you put in various posts on discord/etc, so there should be no issue to have it here as well.

The other change I've made is removing the bullet point about improved internationalization, as that is work not done by you. This is an improvement between Lumafly and Scarab, not LumaflyV2 and Lumafly. While there do appear to be some new strings added, they are not localized and are in English only, so in this respect it is possible that localization is actually worse by some metrics. Other parts of the readme also seem dubious to me based on the commit history but I cannot be bothered to fully fact check them and they are at least not egregiously wrong.

Don't really expect you'll merge this as it seems pretty clear that your main goal here is to stroke your ego by claiming credit for largely the work of others (stars on GitHub is not a good success metric when your customers are non-devs by the way). Feel free to prove me wrong and I'll be pleasantly surprised.