### PR TITLE
Fix macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
           cd Scripts
           # Ensure the published binary is executable before creating the .app bundle
           chmod +x ../Lumafly/bin/Release/net9.0/osx-x64/publish/LumaflyV2 || true
+          chmod +x ./Lumafly.app/Contents/MacOS/Lumafly || true
           python3 make_mac_app.py Lumafly.app ../Lumafly/bin/Release/net9.0/osx-x64/publish ../out
           cd ..
       - name: Upload macos binary

--- a/Scripts/Lumafly.app/Contents/Info.plist
+++ b/Scripts/Lumafly.app/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>LumaflyV2</string>
+	<string>Lumafly</string>
 	<key>CFBundleGetInfoString</key>
 	<string>LumaflyV2</string>
 	<key>CFBundleIconFile</key>

--- a/Scripts/make_mac_app.py
+++ b/Scripts/make_mac_app.py
@@ -113,9 +113,9 @@ with ZipFile(out / "LumaflyV2-mac.zip", 'w', ZIP_DEFLATED) as zip_f:
                 zip_path = root / "MacOS" / fname
                 zip_f.write(path, zip_path)
 
-    # Add the published executable into Contents/MacOS with the expected name
-    # and executable bits. This ensures the app bundle opens correctly on macOS.
-    write_executable(zip_f, publish_root / "LumaflyV2", root / "MacOS" / "LumaflyV2")
+        # Add the published executable into Contents/MacOS with the expected name
+        # and executable bits. This ensures the app bundle opens correctly on macOS.
+        write_executable(zip_f, publish_root / "LumaflyV2", root / "MacOS" / "run")
 
 
 print("Created LumaflyV2-mac.zip")


### PR DESCRIPTION
the actual executable was mistakenly written to the Resources folder as the write_executable line was (accidentally?) unindented by 1 level

after fiddling around, renaming the main executable to Lumafly and adding the executable flag to it (as its a "helper" executable that calls the actual `run` exe) seems to make the app work